### PR TITLE
perf(Intersectable): turn Intersectable into a struct

### DIFF
--- a/Engine/Geometry/Intersectable.cs
+++ b/Engine/Geometry/Intersectable.cs
@@ -8,7 +8,7 @@ public interface IIntersectable
 }
 
 
-public record Intersection(float Distance, Vector3 Point, Vector3 Normal, Ray Ray, Geometry Geometry)
+public record struct Intersection(float Distance, Vector3 Point, Vector3 Normal, Ray Ray, Geometry Geometry)
 {
     public static Intersection Undefined => new(0f, Vector3.Zero, Vector3.Zero, null!, null!); // TODO: null reference, remove this whole field when you can
 }


### PR DESCRIPTION
it had no visual consequences, and we never have to store a reference to an intersection for later use. Thus, intuitively, it can be a struct